### PR TITLE
Directed edges

### DIFF
--- a/src/graphProject/Edge.java
+++ b/src/graphProject/Edge.java
@@ -1,7 +1,10 @@
 package graphProject;
 
-public class Edge<T> implements Comparable<Edge<T>>
+import java.io.Serializable;
+
+public class Edge<T> implements Comparable<Edge<T>>, Serializable
 {
+	private final static long serialVersionUID = 0L;
 	private final T destiantion;
 	private double weight;
 

--- a/src/graphProject/Edge.java
+++ b/src/graphProject/Edge.java
@@ -10,8 +10,8 @@ public class Edge<T> implements Comparable<Edge<T>>, Serializable
 
 	public Edge(final T node, double weight)
 	{
-		if(weight < 1)
-			throw new IllegalArgumentException("Weight must not be negative or zero");
+		if(weight < 0)
+			throw new IllegalArgumentException("Weight must not be negative");
 		this.destiantion = node;
 		this.weight = weight;
 	}

--- a/src/graphProject/Edge.java
+++ b/src/graphProject/Edge.java
@@ -2,32 +2,25 @@ package graphProject;
 
 public class Edge<T> implements Comparable<Edge<T>>
 {
-	private final T node1;
-	private final T node2;
+	private final T destiantion;
 	private int weight;
 
-	public Edge(final T node1, final T node2, int weight)
+	public Edge(final T node, int weight)
 	{
 		if(weight < 1)
 			throw new IllegalArgumentException("Weight must not be negative or zero");
-		this.node1 = node1;
-		this.node2 = node2;
+		this.destiantion = node;
 		this.weight = weight;
 	}
 
 	public T getSource()
 	{
-		return node1;
+		return destiantion;
 	}
 
 	public T getDestination()
 	{
-		return node2;
-	}
-
-	public T getDestination(final T source)
-	{
-		return (node1.equals(source)) ? node2 : node1;
+		return destiantion;
 	}
 
 	public int getWeight()
@@ -49,11 +42,8 @@ public class Edge<T> implements Comparable<Edge<T>>
 			return false;
 		Edge<T> other = (Edge<T>) object;
 		final boolean sameWeight = this.weight == other.weight;
-		final boolean sameNode1Node1 = this.node1.equals(other.node1);
-		final boolean sameNode2Node2 = this.node2.equals(other.node2);
-		final boolean sameNode1Node2 = this.node1.equals(other.node2);
-		final boolean sameNode2Node1 = this.node2.equals(other.node1);
-		return (sameNode1Node1 && sameNode2Node2 || sameNode1Node2 && sameNode2Node1) && sameWeight;
+		final boolean sameDestination = this.destiantion.equals(other.destiantion);
+		return sameDestination && sameWeight;
 	}
 
 	@Override
@@ -61,15 +51,14 @@ public class Edge<T> implements Comparable<Edge<T>>
 	{
 		final int prime = 17;
 		int code = prime*weight;
-		code = code*prime + node1.hashCode();
-		code = code*prime + node2.hashCode();
+		code = code*prime + destiantion.hashCode();
 		return code;
 	}
 
 	@Override
 	public String toString()
 	{
-		return node1.toString() + "<--" + weight + "-->" + node2.toString();
+		return weight + "-->" + destiantion.toString();
 	}
 
 	@Override

--- a/src/graphProject/Edge.java
+++ b/src/graphProject/Edge.java
@@ -3,9 +3,9 @@ package graphProject;
 public class Edge<T> implements Comparable<Edge<T>>
 {
 	private final T destiantion;
-	private int weight;
+	private double weight;
 
-	public Edge(final T node, int weight)
+	public Edge(final T node, double weight)
 	{
 		if(weight < 1)
 			throw new IllegalArgumentException("Weight must not be negative or zero");
@@ -23,12 +23,12 @@ public class Edge<T> implements Comparable<Edge<T>>
 		return destiantion;
 	}
 
-	public int getWeight()
+	public double getWeight()
 	{
 		return weight;
 	}
 
-	public void setWeight(int weight)
+	public void setWeight(double weight)
 	{
 		this.weight = weight;
 	}
@@ -50,9 +50,9 @@ public class Edge<T> implements Comparable<Edge<T>>
 	public int hashCode()
 	{
 		final int prime = 17;
-		int code = prime*weight;
+		double code = prime*weight;
 		code = code*prime + destiantion.hashCode();
-		return code;
+		return new Double(code).intValue();
 	}
 
 	@Override
@@ -64,7 +64,7 @@ public class Edge<T> implements Comparable<Edge<T>>
 	@Override
 	public int compareTo(Edge<T> other)
 	{
-		return this.weight - other.weight;
+		return new Double(this.weight - other.weight).intValue();
 	}
 
 }

--- a/src/graphProject/Graph.java
+++ b/src/graphProject/Graph.java
@@ -1,13 +1,15 @@
 package graphProject;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
-public interface Graph<T>
+public interface Graph<T> extends Collection<T>
 {
 	boolean add(T data);
-	boolean remove(T data);
-	boolean contains(T data);
+	boolean remove(Object data);
+	boolean contains(Object data);
 	int edgeSize(T data);
 	boolean isConnected(T start, T end);
 	boolean connect(T start, T end, int weight);
@@ -20,5 +22,5 @@ public interface Graph<T>
 	int getNumberOfEdges();
 	void clear();
 	T getNodeWithLeastEdges();
-	Set<Edge<T>> getAllEdges();
+	Map<T, List<Edge<T>>> getAllEdges();
 }

--- a/src/graphProject/Graph.java
+++ b/src/graphProject/Graph.java
@@ -12,9 +12,9 @@ public interface Graph<T> extends Collection<T>
 	boolean contains(Object data);
 	int edgeSize(T data);
 	boolean isConnected(T start, T end);
-	boolean connect(T start, T end, int weight);
+	boolean connect(T start, T end, double weight);
 	boolean disconnect(T start, T end);
-	int getWeight(T start, T end);
+	double getWeight(T start, T end);
 	Set<T> getAllNodes();
 	List<Edge<T>> getEdgesFor(T node);
 	Edge<T> getEdgeBetween(T node1, T node2);

--- a/src/graphProject/PathFinder.java
+++ b/src/graphProject/PathFinder.java
@@ -244,4 +244,12 @@ public class PathFinder<T> implements GraphExplorer<T>
 				return edge;
 		return null;
 	}
+
+
+	@Override
+	public List<T> breadthFirstSearch(T start, T end)
+	{
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/src/graphProject/PathFinder.java
+++ b/src/graphProject/PathFinder.java
@@ -22,7 +22,7 @@ public class PathFinder<T> implements GraphExplorer<T>
 	private Set<T> visitedNodes;
 	private Queue<PathRecord<T>> nodes;
 	private Map<T, T> nodePath;
-	private Map<T, Integer> nodeWeight;
+	private Map<T, Double> nodeWeight;
 	
 	public PathFinder(Graph<T> graph)
 	{
@@ -33,7 +33,7 @@ public class PathFinder<T> implements GraphExplorer<T>
 	private void setupDataStructures()
 	{
 		nodePath = new HashMap<T, T>(graph.size());
-		nodeWeight = new HashMap<T, Integer>(graph.size());
+		nodeWeight = new HashMap<T, Double>(graph.size());
 		visitedNodes = new HashSet<T>(graph.size());
 		nodes = new PriorityQueue<PathRecord<T>>();
 	}
@@ -74,10 +74,10 @@ public class PathFinder<T> implements GraphExplorer<T>
 
 	private void createWeightRecords(T start)
 	{
-		nodeWeight.put(start, 0);
+		nodeWeight.put(start, 0.0);
 		for(T node:graph.getAllNodes())
 			if(!node.equals(start))
-				nodeWeight.put(node, Integer.MAX_VALUE);
+				nodeWeight.put(node, Double.MAX_VALUE);
 	}
 
 	@Override
@@ -92,19 +92,19 @@ public class PathFinder<T> implements GraphExplorer<T>
 
 	private void updateEdges(PathRecord<T> currentRecord)
 	{
-		int currentWeight = nodeWeight.get(currentRecord.getNode());
+		double currentWeight = nodeWeight.get(currentRecord.getNode());
 		List<Edge<T>> connectingEdges = graph.getEdgesFor(currentRecord.getNode());
 		for(Edge<T> edge:connectingEdges)
 		{
-			int newWeightForNode = currentWeight + edge.getWeight();
+			double newWeightForNode = currentWeight + edge.getWeight();
 			if(updatePathRecord(currentRecord.getNode(), edge.getDestination(), newWeightForNode) && !visitedNodes.contains(edge.getDestination())) 
 				nodes.add(new PathRecord<T>(edge.getDestination(), currentRecord.getNode(), newWeightForNode));
 		}		
 	}
 
-	private boolean updatePathRecord(T node, T destination, int newWeightForNode)
+	private boolean updatePathRecord(T node, T destination, double newWeightForNode)
 	{
-		int currentWeightForNode = nodeWeight.get(destination);
+		double currentWeightForNode = nodeWeight.get(destination);
 		if(newWeightForNode < currentWeightForNode)
 		{
 			nodePath.put(destination, node);

--- a/src/graphProject/PathFinder.java
+++ b/src/graphProject/PathFinder.java
@@ -187,7 +187,7 @@ public class PathFinder<T> implements GraphExplorer<T>
 	{
 		setupDataStructures();
 		Graph<T> mst = new ConcurrentGraph<T>();
-		Queue<Edge<T>> edges = new PriorityQueue<Edge<T>>(graph.getAllEdges());
+		Queue<Edge<T>> edges = new PriorityQueue<Edge<T>>();
 		final int nodesInCompleteGraph = graph.size();
 		
 		while(mst.getNumberOfEdges() + 1 < nodesInCompleteGraph)

--- a/src/graphProject/PathRecord.java
+++ b/src/graphProject/PathRecord.java
@@ -3,16 +3,16 @@ package graphProject;
 public class PathRecord<T> implements Comparable<PathRecord<T>>
 {
 	private final T node;
-	private final int weight;
+	private final double weight;
 	private final T reachedThrough;
 	
-	public PathRecord(T node, T reachedThrough, int weight)
+	public PathRecord(T node, T reachedThrough, double newWeightForNode)
 	{
 		this.node = node;
 		this.reachedThrough = reachedThrough;
-		if(weight < 0)
+		if(newWeightForNode < 0)
 			throw new IllegalArgumentException("Weight must not be negative!");
-		this.weight = weight;
+		this.weight = newWeightForNode;
 	}
 	
 	public PathRecord(T node)
@@ -26,7 +26,7 @@ public class PathRecord<T> implements Comparable<PathRecord<T>>
 		return node;
 	}
 	
-	int getWeight()
+	double getWeight()
 	{
 		return weight;
 	}
@@ -39,7 +39,7 @@ public class PathRecord<T> implements Comparable<PathRecord<T>>
 	@Override
 	public int compareTo(PathRecord<T> other)
 	{
-		return this.weight - other.weight;
+		return new Double(this.weight - other.weight).intValue();
 	}
 	
 	@Override

--- a/src/graphProject/concurrent/ConcurrentGraph.java
+++ b/src/graphProject/concurrent/ConcurrentGraph.java
@@ -4,6 +4,7 @@ import graphProject.Edge;
 import graphProject.Graph;
 
 import java.io.Serializable;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -11,41 +12,47 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 
-public class ConcurrentGraph<T> implements Graph<T>, Serializable
+public class ConcurrentGraph<T> extends HashSet<T> implements Graph<T>, Serializable
 {
 	/**
 	 * 
 	 */
 	private static final long serialVersionUID = 2473878382917498580L;
-	//private final Map<T, List<Edge<T>>> nodeConnections = new HashMap<T, List<Edge<T>>>();
-	private final Set<T> nodes = new HashSet<T>();
-	private final Set<Edge<T>> edges = new HashSet<Edge<T>>();
+	private final ConcurrentHashMap<T, List<Edge<T>>> edges;
 	
 	public ConcurrentGraph(Collection<T> nodes)
 	{
-		this.nodes.addAll(nodes);
+		addAll(nodes);
+		edges = new ConcurrentHashMap<T, List<Edge<T>>>(nodes.size(), 0.8f, 3);
 	}
 
 	public ConcurrentGraph()
 	{
+		edges = new ConcurrentHashMap<T, List<Edge<T>>>(100, 0.8f, 3);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public boolean add(T data)
+	public boolean remove(Object data)
 	{
-		return nodes.add(data);
-	}
-
-	@Override
-	public boolean remove(T data)
-	{
-		if(!nodes.contains(data))
+		if(!contains(data))
 			return false;
-		removeConnectionsTo(data);
-		return nodes.remove(data);
+		removeConnectionsTo((T) data);
+		synchronized(this)
+		{
+			return super.remove(data);
+		}
+	}
+	
+	@Override
+	public synchronized boolean add(T data)
+	{
+		return super.add(data);
 	}
 	
 	private void removeConnectionsTo(T data)
@@ -53,12 +60,6 @@ public class ConcurrentGraph<T> implements Graph<T>, Serializable
 		final List<Edge<T>> edges = new ArrayList<Edge<T>>(getEdgesFor(data));
 		for(Edge<T> edge:edges)
 			disconnect(data, edge.getDestination());
-	}
-
-	@Override
-	public boolean contains(T data)
-	{
-		return nodes.contains(data);
 	}
 
 	@Override
@@ -72,31 +73,18 @@ public class ConcurrentGraph<T> implements Graph<T>, Serializable
 	@Override
 	public Edge<T> getEdgeBetween(T node1, T node2)
 	{
-		for(Edge<T> edge:edges)
-		{
-			if(edge.getSource().equals(node1) && edge.getDestination().equals(node2))
+		List<Edge<T>> edgeList = edges.get(node1);
+		for(Edge<T> edge : edgeList)
+			if(edge.getDestination().equals(node2))
 				return edge;
-		}
 		return null;
 	}
-
-	@Override
-	public int size()
-	{
-		return nodes.size();
-	}
-	
-	@Override
-	public void clear()
-	{
-		nodes.clear();
-	}	
 
 	@Override
 	public boolean connect(T start, T end, int weight)
 	{
 		if(!nodesExist(start, end))
-			return false;
+			throw new NoSuchElementException();
 		if(isConnected(start, end))
 			changeWeight(start, end, weight);
 		else
@@ -106,9 +94,7 @@ public class ConcurrentGraph<T> implements Graph<T>, Serializable
 	
 	private boolean nodesExist(T node1, T node2)
 	{
-		if(nodes.contains(node1) && nodes.contains(node2))
-			return true;
-		return false;
+		return contains(node1) && contains(node2);
 	}
 	
 	private void changeWeight(T source, T destination, int weight)
@@ -121,9 +107,15 @@ public class ConcurrentGraph<T> implements Graph<T>, Serializable
 
 	private void createEdge(T source, T destination, int weight)
 	{
-		Edge<T> edge = new Edge<T>(source, destination, weight);
-		if(!edges.contains(edge))
-			edges.add(edge);
+		edges.putIfAbsent(source, new ArrayList<Edge<T>>(3));
+		List<Edge<T>> edgeList = edges.get(source);
+		Edge<T> edge = new Edge<T>(destination, weight);
+		edgeList.add(edge);
+		
+		edges.putIfAbsent(destination, new ArrayList<Edge<T>>(3));
+		edgeList = edges.get(destination);
+		edge = new Edge<T>(source, weight);
+		edgeList.add(edge);
 	}
 
 	@Override
@@ -153,30 +145,30 @@ public class ConcurrentGraph<T> implements Graph<T>, Serializable
 	public boolean isConnected(T start, T end)
 	{
 		if(!nodesExist(start, end))
-			return false;
+			throw new NoSuchElementException();
 		List<Edge<T>> edges = getEdgesFor(start);
 		for(Edge<T> edge:edges)
-		{
 			if(edge.getDestination().equals(end))
 				return true;
-		}
 		return false;
 	}
 	
 	@Override
 	public int getNumberOfEdges()
 	{
-		return edges.size();
+		int size = 0;
+		for(List<Edge<T>> edgeList : edges.values())
+			size += edgeList.size();
+		return size/2;
 	}
 	
 	@Override
 	public List<Edge<T>> getEdgesFor(T node)
 	{
-		List<Edge<T>> edgesForNode = new ArrayList<Edge<T>>();
-		for(Edge<T> edge : edges)
-			if(edge.getSource().equals(node))
-				edgesForNode.add(edge);
-		return edgesForNode;
+		final List<Edge<T>> edgeList = edges.get(node);
+		if(edgeList == null)
+			return new ArrayList<Edge<T>>(1);
+		return edgeList;
 	}
 
 	@Override
@@ -188,7 +180,7 @@ public class ConcurrentGraph<T> implements Graph<T>, Serializable
 	@Override
 	public Set<T> getAllNodes()
 	{
-		return nodes;
+		return (Set<T>) this;
 	}
 	
 	@Override
@@ -196,7 +188,7 @@ public class ConcurrentGraph<T> implements Graph<T>, Serializable
 	{
 		int lowestAmountOfEdges = Integer.MAX_VALUE;
 		T nodeWitLowestAmountOfEdges = null;
-		for(T node : nodes)
+		for(T node : this)
 		{
 			final int numberOfEdges = getEdgesFor(node).size();
 			if(numberOfEdges < lowestAmountOfEdges)
@@ -207,7 +199,7 @@ public class ConcurrentGraph<T> implements Graph<T>, Serializable
 	}
 
 	@Override
-	public Set<Edge<T>> getAllEdges()
+	public Map<T, List<Edge<T>>> getAllEdges()
 	{
 		return edges;
 	}

--- a/src/graphProject/concurrent/ConcurrentGraph.java
+++ b/src/graphProject/concurrent/ConcurrentGraph.java
@@ -63,7 +63,7 @@ public class ConcurrentGraph<T> extends HashSet<T> implements Graph<T>, Serializ
 	}
 
 	@Override
-	public int getWeight(T start, T end)
+	public double getWeight(T start, T end)
 	{
 		if(!isConnected(start, end))
 			return -1;
@@ -81,7 +81,7 @@ public class ConcurrentGraph<T> extends HashSet<T> implements Graph<T>, Serializ
 	}
 
 	@Override
-	public boolean connect(T start, T end, int weight)
+	public boolean connect(T start, T end, double weight)
 	{
 		if(!nodesExist(start, end))
 			throw new NoSuchElementException();
@@ -97,7 +97,7 @@ public class ConcurrentGraph<T> extends HashSet<T> implements Graph<T>, Serializ
 		return contains(node1) && contains(node2);
 	}
 	
-	private void changeWeight(T source, T destination, int weight)
+	private void changeWeight(T source, T destination, double weight)
 	{
 		Edge<T> edgeFromSource = getEdgeBetween(source, destination);
 		edgeFromSource.setWeight(weight);
@@ -105,7 +105,7 @@ public class ConcurrentGraph<T> extends HashSet<T> implements Graph<T>, Serializ
 		edgeFromDestination.setWeight(weight);
 	}
 
-	private void createEdge(T source, T destination, int weight)
+	private void createEdge(T source, T destination, double weight)
 	{
 		edges.putIfAbsent(source, new ArrayList<Edge<T>>(3));
 		List<Edge<T>> edgeList = edges.get(source);


### PR DESCRIPTION
…Interface Collection. ConcurrentGraph now also extends HashSet instead of having a HashSet object. Edges are serializable and now uses doubles instead of integers and allows a weight of zero.
